### PR TITLE
Changed birth_date from Date to Date Only

### DIFF
--- a/.forestadmin-schema.json
+++ b/.forestadmin-schema.json
@@ -721,7 +721,7 @@
       "validations": []
     }, {
       "field": "birth_date",
-      "type": "Date",
+      "type": "Dateonly",
       "default_value": null,
       "enums": null,
       "integration": null,


### PR DESCRIPTION
With the new database dump, customer birth date is now a Date Only field.